### PR TITLE
Slight changed the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Copyright 2023 DeepMind Technologies Limited.
 
 ### Citation
 
-If you want to download the pdf of this [paper](https://arxiv.org/pdf/2212.12794.pdf)
+If you want to download the pdf of this [paper](https://arxiv.org/pdf/2212.12794.pdf).
 
 If you want to cite our paper, please use this bibtex in your latex:
 ```latex

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The one-step implementation of GraphCast architecture, is provided in
 [Python](https://www.python.org/),
 [SciPy](https://scipy.org/),
 [Tree](https://github.com/deepmind/tree),
-[Trimesh](https://github.com/mikedh/trimesh) and
+[Trimesh](https://github.com/mikedh/trimesh), and
 [XArray](https://github.com/pydata/xarray).
 
 
@@ -113,8 +113,9 @@ Copyright 2023 DeepMind Technologies Limited.
 
 ### Citation
 
-If you use this work, consider citing our [paper](https://arxiv.org/abs/2212.12794):
+If you want to download the pdf of this [paper](https://arxiv.org/pdf/2212.12794.pdf)
 
+If you want to cite our paper, please use this bibtex in your latex:
 ```latex
 @article{lam2022graphcast,
       title={GraphCast: Learning skillful medium-range global weather forecasting},
@@ -122,6 +123,7 @@ If you use this work, consider citing our [paper](https://arxiv.org/abs/2212.127
       year={2022},
       eprint={2212.12794},
       archivePrefix={arXiv},
+      journal={arXiv preprint arXiv:2212.12794},
       primaryClass={cs.LG}
 }
 ```


### PR DESCRIPTION
The Current citation section is like this. 
![image](https://github.com/google-deepmind/graphcast/assets/27912581/2d392795-6d7b-4861-b3e6-0c1087592416)

I changed it slightly so that anyone can download the paper if they wish to read it, as the paper link is already provided in the first section of the documentation. 

After changing, the documentation will be like this:

![image](https://github.com/google-deepmind/graphcast/assets/27912581/759ecdb8-73cf-4c12-8a8f-dea613d9ae4c)
