### PR TITLE
Update xarray_jax.py

### DIFF
--- a/graphcast/xarray_jax.py
+++ b/graphcast/xarray_jax.py
@@ -104,7 +104,7 @@ from typing import Any, Callable, Hashable, Iterator, Mapping, Optional, Union, 
 import jax
 import jax.numpy as jnp
 import numpy as np
-import tree
+from graphcast import xarray_tree as tree
 import xarray
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "trimesh",
         "typing_extensions",
         "xarray",
+        "google-cloud-storage"
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
The original code will report an error because it uses 'import tree' directly. The tree package actually used is our own defined xarray_tree.py.  So, I replace 'import tree' with 'from graphcast import xarray_tree as tree' and the error is been solved.