### PR TITLE
Adding pip installation of Cython.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "cartopy",
         "chex",
         "colabtools",
+        "Cython",
         "dask",
         "dm-haiku",
         "jax",


### PR DESCRIPTION
When unpacking and attempting to deploy the Graphcast application, certain packages do not work without Cython. This would resolve that issue.