### PR TITLE
Use xarray.Dataset/Array.sizes instead of .dims

### DIFF
--- a/graphcast/autoregressive.py
+++ b/graphcast/autoregressive.py
@@ -112,7 +112,7 @@ class Predictor(predictor_base.Predictor):
                        f'forcings, which isn\'t allowed: {overlap}')
 
   def _update_inputs(self, inputs, next_frame):
-    num_inputs = inputs.dims['time']
+    num_inputs = inputs.sizes['time']
 
     predicted_or_forced_inputs = next_frame[list(inputs.keys())]
 
@@ -199,7 +199,7 @@ class Predictor(predictor_base.Predictor):
       return next_inputs, flat_pred
 
     if self._gradient_checkpointing:
-      scan_length = targets_template.dims['time']
+      scan_length = targets_template.sizes['time']
       if scan_length <= 1:
         logging.warning(
             'Skipping gradient checkpointing for sequence length of 1')

--- a/graphcast/rollout.py
+++ b/graphcast/rollout.py
@@ -124,7 +124,7 @@ def chunked_prediction_generator(
   if "datetime" in forcings.coords:
     del forcings.coords["datetime"]
 
-  num_target_steps = targets_template.dims["time"]
+  num_target_steps = targets_template.sizes["time"]
   num_chunks, remainder = divmod(num_target_steps, num_steps_per_chunk)
   if remainder != 0:
     raise ValueError(
@@ -202,7 +202,7 @@ def _get_next_inputs(
   next_inputs = next_frame[next_inputs_keys]
 
   # Apply concatenate next frame with inputs, crop what we don't need.
-  num_inputs = prev_inputs.dims["time"]
+  num_inputs = prev_inputs.sizes["time"]
   return (
       xarray.concat(
           [prev_inputs, next_inputs], dim="time", data_vars="different")


### PR DESCRIPTION
There are a few places where the syntax `xarray.Dataset.dims[varname]` is used to get the length of e.g. `varname`. This produces the following warning of to-be-deprecated behavior

```
graphcast/graphcast/autoregressive.py:115: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```

(for reference this is with xarray version 2024.5.0)

This PR makes the replacement suggested by the warning. I think these are all the spots where this functionality of `.dims` is used, it's at least a good start.