### PR TITLE
Use HTTPS for privacy policy link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,4 +228,4 @@ Use of the third-party materials referred to above may be governed by separate t
 
 ## Contact
 
-For feedback and questions, contact us at gencast@google.com. Any information collected via email will be used in accordance with [Google's privacy policy](http://policies.google.com/privacy).
+For feedback and questions, contact us at gencast@google.com. Any information collected via email will be used in accordance with [Google's privacy policy](https://policies.google.com/privacy).


### PR DESCRIPTION
## Summary
- Replace insecure `http://policies.google.com/privacy` with `https://policies.google.com/privacy` in the Contact section

## Test plan
- [x] Verified `https://policies.google.com/privacy` resolves correctly
- [x] Single link update, no other changes