### PR TITLE
Fix JaxArrayWrapper TypeError with JAX tracers during JIT

### DIFF
--- a/graphcast/xarray_jax.py
+++ b/graphcast/xarray_jax.py
@@ -115,7 +115,7 @@ import xarray
 # leaves of pytrees, in order to ensure we can still use xarray datatypes as
 # internal pytree nodes in these cases.
 _WRAPPED_TYPES = (
-    jax.Array, jax.ShapeDtypeStruct, jax.stages.ArgInfo)
+    jax.Array, jax.ShapeDtypeStruct, jax.stages.ArgInfo, jax.core.Tracer)
 
 
 def Variable(dims, data, **kwargs) -> xarray.Variable:  # pylint:disable=invalid-name
@@ -364,7 +364,7 @@ def unwrap(value, require_jax=False):
   """Unwraps wrapped JAX arrays used in xarray, passing through other values."""
   if isinstance(value, JaxArrayWrapper):
     return value.jax_array
-  elif isinstance(value, jax.Array):
+  elif isinstance(value, (jax.Array, jax.core.Tracer)):
     return value
   elif require_jax:
     raise TypeError(f'Expected JAX array, found {type(value)}.')
@@ -441,7 +441,7 @@ class JaxArrayWrapper(np.lib.mixins.NDArrayOperatorsMixin):
 
   def __array_ufunc__(self, ufunc, method, *args, **kwargs):
     for x in args:
-      if not isinstance(x, (jax.typing.ArrayLike, type(self))):
+      if not isinstance(x, (jax.typing.ArrayLike, jax.core.Tracer, type(self))):
         return NotImplemented
     if method != '__call__':
       return NotImplemented


### PR DESCRIPTION
## Summary

- Fixes the `TypeError: operand type(s) all returned NotImplemented from __array_ufunc__` that occurs during GenCast autoregressive rollout under `jax.jit` tracing
- Adds `jax.core.Tracer` to three locations in `xarray_jax.py` where JAX array types are checked at runtime:
  - `_WRAPPED_TYPES` tuple, so tracers are properly wrapped when constructing xarray structures during tracing
  - `JaxArrayWrapper.__array_ufunc__` isinstance check, so numpy ufuncs (e.g. `multiply`) correctly dispatch when one operand is a raw tracer and the other is a `JaxArrayWrapper`-wrapped tracer
  - `unwrap()` function, so tracers are passed through (like `jax.Array`) instead of falling to the error/passthrough branch

## Root cause

During JIT-traced execution, JAX replaces concrete `jax.Array` objects with `DynamicJaxprTracer` instances. These inherit from `jax.core.Tracer`, not `jax.Array`. The existing type checks in `xarray_jax.py` did not account for tracer types, causing `__array_ufunc__` to return `NotImplemented` when a raw tracer scalar was combined with a `JaxArrayWrapper`-wrapped tracer array.

## Test plan

- [ ] Verify existing `xarray_jax_test.py` tests pass
- [ ] Run GenCast autoregressive rollout (as in the demo notebook) to confirm the `TypeError` no longer occurs

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)